### PR TITLE
Close all instances of safari

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 var fs = require('fs');
 var path = require('path');
-
+var exec = require('child_process').exec;
 
 var SafariBrowser = function(baseBrowserDecorator) {
   baseBrowserDecorator(this);
@@ -17,6 +17,24 @@ var SafariBrowser = function(baseBrowserDecorator) {
         self._execCommand(self._getCommand(), [staticHtmlPath]);
       });
     });
+  };
+
+  var oldEmitAsync = this.emitAsync;
+
+  this.emitAsync = function () {
+    if (arguments[0] !== 'kill') {
+      return oldEmitAsync.apply(this, arguments);
+    } else {
+      return new Promise (function (resolve, reject) {
+        exec('osascript -e \'quit app "Safari"\'', function (err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve();
+          }
+        });
+      });
+    }
   };
 };
 

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var fs = require('fs');
 var path = require('path');
 var exec = require('child_process').exec;
+var Promise = require('bluebird');
 
 var SafariBrowser = function(baseBrowserDecorator) {
   baseBrowserDecorator(this);

--- a/package.json
+++ b/package.json
@@ -16,7 +16,9 @@
     "safari"
   ],
   "author": "Vojta Jina <vojta.jina@gmail.com>",
-  "dependencies": {},
+  "dependencies": {
+    "bluebird": "^3.4.0"
+  },
   "peerDependencies": {
     "karma": ">=0.9"
   },


### PR DESCRIPTION
Prevents tabs being kept across test invocations. This is based on the work from https://github.com/gardenvarietyse/karma-safari-launcher/commit/28eb4f19737af74037cb5cf17160f9770172bbd1
